### PR TITLE
Explicit strict_supports in tests

### DIFF
--- a/tests/test_octodns_provider_dnsimple.py
+++ b/tests/test_octodns_provider_dnsimple.py
@@ -138,7 +138,7 @@ class TestDnsimpleProvider(TestCase):
             )
 
     def test_apply(self):
-        provider = DnsimpleProvider('test', 'token', 42)
+        provider = DnsimpleProvider('test', 'token', 42, strict_supports=False)
 
         resp = Mock()
         resp.json = Mock()


### PR DESCRIPTION
As of https://github.com/octodns/octodns/pull/957 we'll need t be explicit in our tests around the expectations of `Provider.strict_supports`. This PR is in preparation of that change. 

/cc https://github.com/octodns/octodns/pull/957