### PR TITLE
Set User-Agent for API requests

### DIFF
--- a/octodns_dnsimple/__init__.py
+++ b/octodns_dnsimple/__init__.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from requests import Session
 import logging
 
+from octodns import __VERSION__ as octodns_version
 from octodns.record import Record
 from octodns.provider import ProviderException
 from octodns.provider.base import BaseProvider
@@ -32,7 +33,12 @@ class DnsimpleClient(object):
     def __init__(self, token, account, sandbox):
         self.account = account
         sess = Session()
-        sess.headers.update({'Authorization': f'Bearer {token}'})
+        sess.headers.update(
+            {
+                'Authorization': f'Bearer {token}',
+                'User-Agent': f'octodns/{octodns_version} octodns-dnsimple/{__VERSION__}',
+            }
+        )
         self._sess = sess
         if sandbox:
             self.base = 'https://api.sandbox.dnsimple.com/v2/'


### PR DESCRIPTION
## What is the problem?

At present the default user agent is used in API requests: `python-requests/*`. This makes it impossible for us at DNSimple to identify active community projects that are using our API, and how to best support them.

## What has changed

With this PR the user agent is changed to: `octodns/0.9.21 octodns-dnsimple/0.0.1` which serves to both identify API usage from the project and also give us debugging data to assist with customer support requests.