### PR TITLE
Version 1.0.1 bump & changelog update

### DIFF
--- a/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
+++ b/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Use new [changelet](https://github.com/octodns/changelet) tooling

--- a/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
+++ b/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Run changelog check during pre-commit

--- a/.changelog/28491e0f69f34462bea04b14b10788e6.md
+++ b/.changelog/28491e0f69f34462bea04b14b10788e6.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
+++ b/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update scripts to use common.sh

--- a/.changelog/5cee496f31f2412f84d4e6907fad17d4.md
+++ b/.changelog/5cee496f31f2412f84d4e6907fad17d4.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/657e683f258d43d8800f93fc13b31cc6.md
+++ b/.changelog/657e683f258d43d8800f93fc13b31cc6.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Use script/common.sh in script/update-requirements

--- a/.changelog/7f722301e34140f7bbf0b4126709342d.md
+++ b/.changelog/7f722301e34140f7bbf0b4126709342d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add JSON coverage report format

--- a/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
+++ b/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Switch to proviso for requirements.txt management

--- a/.changelog/9274ca3afe344e418fca014da9c9e662.md
+++ b/.changelog/9274ca3afe344e418fca014da9c9e662.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/a9819303d8904a00b410721bec016512.md
+++ b/.changelog/a9819303d8904a00b410721bec016512.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/addd674b9559481daae7cfc3b1f28d92.md
+++ b/.changelog/addd674b9559481daae7cfc3b1f28d92.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements.txt

--- a/.changelog/ca398415a3be41cfb208802d20cfa527.md
+++ b/.changelog/ca398415a3be41cfb208802d20cfa527.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Pull in the latest template changes

--- a/.changelog/fc4c48f664bd473abb5213e536948d0d.md
+++ b/.changelog/fc4c48f664bd473abb5213e536948d0d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements*.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.1 - 2026-04-03
+
+Patch:
+* Use new [changelet](https://github.com/octodns/changelet) tooling - [#49](https://github.com/octodns/octodns-dnsimple/pull/49)
+
 ## v1.0.0 - 2025-05-03 - Long overdue 1.0
 
 Noteworthy Changes:

--- a/octodns_dnsimple/__init__.py
+++ b/octodns_dnsimple/__init__.py
@@ -3,7 +3,7 @@
 #
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.0.0'
+__version__ = __VERSION__ = '1.0.1'
 
 
 import logging


### PR DESCRIPTION
## 1.0.1 - 2026-04-03

Patch:
* Use new [changelet](https://github.com/octodns/changelet) tooling - [#49](https://github.com/octodns/octodns-dnsimple/pull/49)

